### PR TITLE
exclude community.general 3.3.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: bonddim
 name: linux
 description: Linux roles collection for different purposes
-version: 1.2.0
+version: 1.3.1
 authors:
   - Dmytro Bondar
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,7 +15,7 @@ license_file: LICENSE
 license: []
 
 dependencies:
-  community.general: '>=1.0.0'
+  community.general: '>=1.0.0,!=3.3.0'
   community.docker: '>=1.0.0'
 
 tags:


### PR DESCRIPTION
- Exclude community.general 3.3.0 with broken snap module
- Set version
