### PR TITLE
Initial support for AWS Linux - needs epel role run first

### DIFF
--- a/roles/snapd/tasks/main.yml
+++ b/roles/snapd/tasks/main.yml
@@ -13,8 +13,8 @@
     name: snapd-amzn2
     description: snapd packages for Amazon Linux 2
     file: snapd-amzn2
-    baseurl: "https://people.canonical.com/~mvo/snapd/amazon-linux2/repo/{{ansible_machine}}"
-    gpgcheck: no
+    baseurl: "https://people.canonical.com/~mvo/snapd/amazon-linux2/repo/{{ ansible_machine }}"
+    gpgcheck: false
   when:
     - ansible_distribution == "Amazon"
     - ansible_distribution_major_version == 2

--- a/roles/snapd/tasks/main.yml
+++ b/roles/snapd/tasks/main.yml
@@ -8,6 +8,17 @@
   when: ansible_distribution == "CentOS"
   tags: snap, snap-install
 
+- name: Add custom snap repo for AWS Linux
+  yum_repository:
+    name: snapd-amzn2
+    description: snapd packages for Amazon Linux 2
+    file: snapd-amzn2
+    baseurl: "https://people.canonical.com/~mvo/snapd/amazon-linux2/repo/{{ansible_machine}}"
+    gpgcheck: no
+  when:
+    - ansible_distribution == "Amazon"
+    - ansible_distribution_major_version == 2
+
 - name: Install snapd package
   ansible.builtin.package:
     name: snapd


### PR DESCRIPTION
On AWS Linux snapd is currently supported by an unofficial repo.  This proposed patch adds support for setting up that repo so that snapd can be installed.

https://forum.snapcraft.io/t/unofficial-snapd-repository-for-amazon-linux-2/24269

N.B. EPEL also needs to be separately installed since it also isn't directly available in the AWS linux default repositories.  I used the robertdebock.epel galaxy role to do that.  

