### PR TITLE
some documentation and metadata for AWS linux in snap role also dependency 

### DIFF
--- a/roles/snapd/README.md
+++ b/roles/snapd/README.md
@@ -6,6 +6,7 @@ Install snap core and packages from https://snapcraft.io/store
 * Debian based distributions
 * CentOS 7/8
 * Fedora
+* Amazon Linux 2
 
 ## Role Variables
 ```yaml

--- a/roles/snapd/meta/main.yml
+++ b/roles/snapd/meta/main.yml
@@ -15,4 +15,7 @@ galaxy_info:
     - name: EL
       versions:
         - all
+    - name: Amazon
+      versions:
+        - all
   galaxy_tags: []

--- a/roles/snapd/tasks/main.yml
+++ b/roles/snapd/tasks/main.yml
@@ -13,13 +13,14 @@
 - name: Add custom snap repo for AWS Linux
   yum_repository:
     name: snapd-amzn2
+    priority: 15
     description: snapd packages for Amazon Linux 2
     file: snapd-amzn2
     baseurl: "https://people.canonical.com/~mvo/snapd/amazon-linux2/repo/{{ ansible_machine }}"
     gpgcheck: false
   when:
     - ansible_distribution == "Amazon"
-    - ansible_distribution_major_version == 2
+    - ansible_distribution_major_version == "2"
 
 - name: Install snapd package
   ansible.builtin.package:

--- a/roles/snapd/tasks/main.yml
+++ b/roles/snapd/tasks/main.yml
@@ -8,6 +8,8 @@
   when: ansible_distribution == "CentOS"
   tags: snap, snap-install
 
+# See https://forum.snapcraft.io/t/unofficial-snapd-repository-for-amazon-linux-2/24269
+# for full information on this.
 - name: Add custom snap repo for AWS Linux
   yum_repository:
     name: snapd-amzn2


### PR DESCRIPTION
Here's a little documentation and meta info following on from my previous patch. 

I've put a separate commit at the end with the dependency on the role that I used.  The role doesn't use the `amazon-linux-extras` command which I guess might be better.  There doesn't seem to be any role that does use that command though, which I'm not sure how to take.  