### PR TITLE
Add test for snapd on amzn2

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -37,5 +37,13 @@
         "install_method": "docker"
       }
     ]
+  },
+  "snapd": {
+    "include": [
+      {
+        "ansible": "stable-2.10",
+        "distro": "amazonlinux/2.0.20210525.0"
+      }
+    ]
   }
 }

--- a/roles/snapd/meta/main.yml
+++ b/roles/snapd/meta/main.yml
@@ -1,7 +1,9 @@
 ---
-dependencies: []
+dependencies:
+  - { role: bonddim.linux.epel, when: ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora' }
+
 galaxy_info:
-  description: "Install snap core and snap packages from https://snapcraft.io/store"
+  description: 'Install snap core and snap packages from https://snapcraft.io/store'
   platforms:
     - name: Ubuntu
       versions:

--- a/roles/snapd/tasks/main.yml
+++ b/roles/snapd/tasks/main.yml
@@ -19,7 +19,7 @@
     state: present
     update_cache: true
     enablerepo: "{{ (ansible_distribution == 'CentOS') | ternary('cr,epel', omit) }}"
-    disable: "{{ (ansible_distribution == 'Amazon') | ternary('epel', omit) }}"
+    disablerepo: "{{ (ansible_distribution == 'Amazon') | ternary('epel', omit) }}"
   tags: snap, snap-install
 
 - name: Install fuse packages to run snaps in virtualized environments

--- a/roles/snapd/tasks/main.yml
+++ b/roles/snapd/tasks/main.yml
@@ -1,19 +1,10 @@
 # tasks file for snapd role
 ---
-- name: Ensure that EPEL package is installed
-  ansible.builtin.package:
-    name: epel-release
-    state: present
-    update_cache: true
-  when: ansible_distribution == "CentOS"
-  tags: snap, snap-install
-
 # See https://forum.snapcraft.io/t/unofficial-snapd-repository-for-amazon-linux-2/24269
 # for full information on this.
 - name: Add custom snap repo for AWS Linux
   yum_repository:
     name: snapd-amzn2
-    priority: 15
     description: snapd packages for Amazon Linux 2
     file: snapd-amzn2
     baseurl: "https://people.canonical.com/~mvo/snapd/amazon-linux2/repo/{{ ansible_machine }}"
@@ -28,6 +19,7 @@
     state: present
     update_cache: true
     enablerepo: "{{ (ansible_distribution == 'CentOS') | ternary('cr,epel', omit) }}"
+    disable: "{{ (ansible_distribution == 'Amazon') | ternary('epel', omit) }}"
   tags: snap, snap-install
 
 - name: Install fuse packages to run snaps in virtualized environments


### PR DESCRIPTION
- Disable EPEL repo during snapd installation on Amazon Linux
- Run epel role conditionally as dependency